### PR TITLE
Layout-defined buffer allocation

### DIFF
--- a/rebpf/src/libbpf.rs
+++ b/rebpf/src/libbpf.rs
@@ -370,7 +370,7 @@ pub fn bpf_prog_load(
 pub fn bpf_map_lookup_elem<K, V, L: MapLayout>(
     map_fd: &BpfMapFd<K, V, L>,
     key: &K,
-    value: impl WritePointer<V, L>,
+    value: &mut impl WritePointer<V, L>,
 ) -> Option<()> {
     let key_void_p = to_const_c_void(key);
     match unsafe { libbpf_sys::bpf_map_lookup_elem(map_fd.fd(), key_void_p, value.get_ptr_mut()) } {
@@ -384,7 +384,7 @@ pub fn bpf_map_lookup_elem<K, V, L: MapLayout>(
 pub fn bpf_map_update_elem<K, V, L: MapLayout>(
     map_fd: &BpfMapFd<K, V, L>,
     key: &K,
-    value: impl ReadPointer<V, L>,
+    value: &impl ReadPointer<V, L>,
     flags: BpfUpdateElemFlags,
 ) -> Result<()> {
     let key = to_const_c_void(key);

--- a/rebpf/src/map_layout.rs
+++ b/rebpf/src/map_layout.rs
@@ -85,6 +85,22 @@ unsafe impl<T> WritePointer<T, PerCpuLayout> for Vec<MaybeUninit<PerCpuValue<T>>
 mod test {
     use super::*;
     use std::mem::{align_of, size_of};
+
+    #[test]
+    fn percpu_value_roundtrip() {
+        // A standard type
+        assert_eq!(42, *PerCpuValue::from(42).as_ref());
+
+        // A bare type with no special trait whatsoever.
+        struct NoDerive {
+            content: usize,
+        };
+        assert_eq!(
+            42,
+            PerCpuValue::from(NoDerive { content: 42 }).as_ref().content
+        );
+    }
+
     #[test]
     fn layout_smaller_content() {
         assert_eq!(size_of::<PerCpuValue<u32>>(), 8);

--- a/rebpf/src/map_layout.rs
+++ b/rebpf/src/map_layout.rs
@@ -45,7 +45,7 @@ impl MapLayout for PerCpuLayout {}
 
 /// Individual value wrapper for the PerCpuLayout
 #[repr(align(8))]
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct PerCpuValue<T>(T);
 
 lazy_static! {

--- a/rebpf/src/map_layout.rs
+++ b/rebpf/src/map_layout.rs
@@ -12,27 +12,27 @@ pub trait MapLayout {}
 /// Trait denoting a read access to an underlying memory storage
 /// organised according to a specific data layout.
 pub unsafe trait ReadPointer<T, L: MapLayout> {
-    fn get_ptr(self) -> *const raw::c_void;
+    fn get_ptr(&self) -> *const raw::c_void;
 }
 
 /// Trait denoting a write access to an underlying memory storage
 /// organised according to a specific data layout.
 pub unsafe trait WritePointer<T, L: MapLayout> {
-    fn get_ptr_mut(self) -> *mut raw::c_void;
+    fn get_ptr_mut(&mut self) -> *mut raw::c_void;
 }
 
 /// The simplest data layout, a single, scalar value.
 pub struct ScalarLayout;
 impl MapLayout for ScalarLayout {}
 
-unsafe impl<T> ReadPointer<T, ScalarLayout> for &T {
-    fn get_ptr(self) -> *const raw::c_void {
+unsafe impl<T> ReadPointer<T, ScalarLayout> for T {
+    fn get_ptr(&self) -> *const raw::c_void {
         self as *const T as *const raw::c_void
     }
 }
 
-unsafe impl<T> WritePointer<T, ScalarLayout> for &mut MaybeUninit<T> {
-    fn get_ptr_mut(self) -> *mut raw::c_void {
+unsafe impl<T> WritePointer<T, ScalarLayout> for MaybeUninit<T> {
+    fn get_ptr_mut(&mut self) -> *mut raw::c_void {
         self.as_mut_ptr() as *mut raw::c_void
     }
 }
@@ -66,15 +66,16 @@ impl<T> AsRef<T> for PerCpuValue<T> {
     }
 }
 
-unsafe impl<T> ReadPointer<T, PerCpuLayout> for &Vec<PerCpuValue<T>> {
-    fn get_ptr(self) -> *const raw::c_void {
+
+unsafe impl<T> ReadPointer<T, PerCpuLayout> for Vec<PerCpuValue<T>> {
+    fn get_ptr(&self) -> *const raw::c_void {
         assert!(self.len() == *NB_CPUS, "size mismatch");
         self.as_ptr() as *const raw::c_void
     }
 }
 
-unsafe impl<T> WritePointer<T, PerCpuLayout> for &mut Vec<MaybeUninit<PerCpuValue<T>>> {
-    fn get_ptr_mut(self) -> *mut raw::c_void {
+unsafe impl<T> WritePointer<T, PerCpuLayout> for Vec<MaybeUninit<PerCpuValue<T>>> {
+    fn get_ptr_mut(&mut self) -> *mut raw::c_void {
         assert!(self.len() == *NB_CPUS, "size mismatch");
         self.as_mut_ptr() as *mut raw::c_void
     }


### PR DESCRIPTION
As discussed in #16 this PR finalizes pulling all the layout knowledge into the `map_layout` module.