### PR TITLE
Setup CI using GH Actions' default Rust workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,24 @@
+name: Rust
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install dependencies
+      run: sudo apt-get -y install libelf-dev
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,10 +11,16 @@ env:
 
 jobs:
   build:
+    strategy:
+      matrix:
+        rust: [1.34.2, stable, nightly]
 
     runs-on: ubuntu-latest
 
     steps:
+    - uses: hecrj/setup-rust-action@v1
+      with:
+        rust-version: ${{ matrix.rust }}
     - uses: actions/checkout@v2
     - name: Install dependencies
       run: sudo apt-get -y install libelf-dev


### PR DESCRIPTION
CI allows us to make sure that the crate builds and that the tests aren't broken on every PR.