### PR TITLE
Try making some improvements on examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+target
+Cargo.lock
+
+**/ebpf_output/user
+*.ll
+*.o

--- a/examples/basic01_xdp_pass/build.sh
+++ b/examples/basic01_xdp_pass/build.sh
@@ -2,10 +2,8 @@
 BPF_PROG_NAME="kern"
 USER_PROG_NAME="user"
 OUT_DIR="ebpf_output"
-LLVM_DIS=llvm-dis-9
 LLC_OPTIONS="-march=bpf -filetype=obj"
-LLC=llc-9
-OUT_BC=$OUT_DIR"/"$BPF_PROG_NAME".bc"
+LLC=llc
 OUT_IR_TEMP=$OUT_DIR"/"$BPF_PROG_NAME"_temp.ll"
 OUT_IR=$OUT_DIR"/"$BPF_PROG_NAME".ll"
 OUT_ELF=$OUT_DIR"/"$BPF_PROG_NAME".o"
@@ -13,13 +11,12 @@ RM_UND=./remove_undefined_functions.sh
 
 mkdir -p $OUT_DIR
 TARGET_DIRECTORY="target/release/deps"
-TARGET=$(echo $TARGET_DIRECTORY"/kern*.bc")
+TARGET=$(echo $TARGET_DIRECTORY"/kern*.ll")
 if [ -d $TARGET_DIRECTORY ]; then
     rm -f $TARGET
 fi
-cargo rustc --lib --release -- --emit=llvm-bc
-cp $TARGET $OUT_BC
-$LLVM_DIS $OUT_BC -o $OUT_IR_TEMP
+cargo rustc --lib --release -- --emit=llvm-ir
+cp $TARGET $OUT_IR_TEMP
 $RM_UND $OUT_IR_TEMP $OUT_IR
 $LLC $OUT_IR $LLC_OPTIONS -o $OUT_ELF 
 #llvm-objcopy $OUT_ELF --remove-section=.text

--- a/examples/basic01_xdp_pass/remove_undefined_functions.sh
+++ b/examples/basic01_xdp_pass/remove_undefined_functions.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 INPUT_OBJ=$1
 OUTPUT_OBJ=$2
-cat $INPUT_OBJ | sed -E "s/(.*)call(.*)slice_index_len_fail(.*)/  ret i32 0/" | sed -E "s/(.*)call(.*)slice_index_order_fail(.*)/  ret i32 0/" | sed -E "s/(.*)call(.*)panic_bounds_check(.*)/  ret i32 0/" | sed -E "s/unreachable//" > $OUTPUT_OBJ
+cat $INPUT_OBJ | sed -zE "s/\n([^;\n]*)call([^\n]*)std::panic::Location([^\n]*)\n  unreachable\n/\n  ret i32 0\n/g" > $OUTPUT_OBJ

--- a/examples/basic01_xdp_pass/src/user.rs
+++ b/examples/basic01_xdp_pass/src/user.rs
@@ -37,7 +37,7 @@ fn run(bpf_program_path: &Path, interface_name: &str, unload_program: bool) -> R
 }
 
 
-fn main() {
+fn main() -> Result<(), rebpf_error::Error> {
     let matches = App::new("xdp_pass")
         .version("1.0")
         .author("Lorenzo Vannucci lorenzo@vannucci.io")
@@ -58,8 +58,5 @@ fn main() {
     let interface_name = matches.value_of("i").unwrap_or(DEFAULT_DEV);
     let unload_program = matches.is_present("U");
     let bpf_program_path = Path::new(DEFAULT_FILENAME);
-    match run(&bpf_program_path, interface_name, unload_program) {
-        Err(err) => println!("{:?}", err),
-        Ok(_) => {}
-    };
+    run(&bpf_program_path, interface_name, unload_program)
 }

--- a/examples/basic02_prog_by_name/build.sh
+++ b/examples/basic02_prog_by_name/build.sh
@@ -2,10 +2,8 @@
 BPF_PROG_NAME="kern"
 USER_PROG_NAME="user"
 OUT_DIR="ebpf_output"
-LLVM_DIS=llvm-dis-9
 LLC_OPTIONS="-march=bpf -filetype=obj"
-LLC=llc-9
-OUT_BC=$OUT_DIR"/"$BPF_PROG_NAME".bc"
+LLC=llc
 OUT_IR_TEMP=$OUT_DIR"/"$BPF_PROG_NAME"_temp.ll"
 OUT_IR=$OUT_DIR"/"$BPF_PROG_NAME".ll"
 OUT_ELF=$OUT_DIR"/"$BPF_PROG_NAME".o"
@@ -13,13 +11,12 @@ RM_UND=./remove_undefined_functions.sh
 
 mkdir -p $OUT_DIR
 TARGET_DIRECTORY="target/release/deps"
-TARGET=$(echo $TARGET_DIRECTORY"/kern*.bc")
+TARGET=$(echo $TARGET_DIRECTORY"/kern*.ll")
 if [ -d $TARGET_DIRECTORY ]; then
     rm -f $TARGET
 fi
-cargo rustc --lib --release -- --emit=llvm-bc
-cp $TARGET $OUT_BC
-$LLVM_DIS $OUT_BC -o $OUT_IR_TEMP
+cargo rustc --lib --release -- --emit=llvm-ir
+cp $TARGET $OUT_IR_TEMP
 $RM_UND $OUT_IR_TEMP $OUT_IR
 $LLC $OUT_IR $LLC_OPTIONS -o $OUT_ELF 
 #llvm-objcopy $OUT_ELF --remove-section=.text

--- a/examples/basic02_prog_by_name/remove_undefined_functions.sh
+++ b/examples/basic02_prog_by_name/remove_undefined_functions.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 INPUT_OBJ=$1
 OUTPUT_OBJ=$2
-cat $INPUT_OBJ | sed -E "s/(.*)call(.*)slice_index_len_fail(.*)/  ret i32 0/" | sed -E "s/(.*)call(.*)slice_index_order_fail(.*)/  ret i32 0/" | sed -E "s/(.*)call(.*)panic_bounds_check(.*)/  ret i32 0/" | sed -E "s/unreachable//" > $OUTPUT_OBJ
+cat $INPUT_OBJ | sed -zE "s/\n([^;\n]*)call([^\n]*)std::panic::Location([^\n]*)\n  unreachable\n/\n  ret i32 0\n/g" > $OUTPUT_OBJ

--- a/examples/empty_project/build.sh
+++ b/examples/empty_project/build.sh
@@ -2,10 +2,8 @@
 BPF_PROG_NAME="kern"
 USER_PROG_NAME="user"
 OUT_DIR="ebpf_output"
-LLVM_DIS=llvm-dis-9
 LLC_OPTIONS="-march=bpf -filetype=obj"
-LLC=llc-9
-OUT_BC=$OUT_DIR"/"$BPF_PROG_NAME".bc"
+LLC=llc
 OUT_IR_TEMP=$OUT_DIR"/"$BPF_PROG_NAME"_temp.ll"
 OUT_IR=$OUT_DIR"/"$BPF_PROG_NAME".ll"
 OUT_ELF=$OUT_DIR"/"$BPF_PROG_NAME".o"
@@ -13,13 +11,12 @@ RM_UND=./remove_undefined_functions.sh
 
 mkdir -p $OUT_DIR
 TARGET_DIRECTORY="target/release/deps"
-TARGET=$(echo $TARGET_DIRECTORY"/kern*.bc")
+TARGET=$(echo $TARGET_DIRECTORY"/kern*.ll")
 if [ -d $TARGET_DIRECTORY ]; then
     rm -f $TARGET
 fi
-cargo rustc --lib --release -- --emit=llvm-bc
-cp $TARGET $OUT_BC
-$LLVM_DIS $OUT_BC -o $OUT_IR_TEMP
+cargo rustc --lib --release -- --emit=llvm-ir
+cp $TARGET $OUT_IR_TEMP
 $RM_UND $OUT_IR_TEMP $OUT_IR
 $LLC $OUT_IR $LLC_OPTIONS -o $OUT_ELF 
 #llvm-objcopy $OUT_ELF --remove-section=.text

--- a/examples/empty_project/remove_undefined_functions.sh
+++ b/examples/empty_project/remove_undefined_functions.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 INPUT_OBJ=$1
 OUTPUT_OBJ=$2
-cat $INPUT_OBJ | sed -E "s/(.*)call(.*)slice_index_len_fail(.*)/  ret i32 0/" | sed -E "s/(.*)call(.*)slice_index_order_fail(.*)/  ret i32 0/" | sed -E "s/(.*)call(.*)panic_bounds_check(.*)/  ret i32 0/" | sed -E "s/unreachable//" > $OUTPUT_OBJ
+cat $INPUT_OBJ | sed -zE "s/\n([^;\n]*)call([^\n]*)std::panic::Location([^\n]*)\n  unreachable\n/\n  ret i32 0\n/g" > $OUTPUT_OBJ

--- a/examples/packet_parser/build.sh
+++ b/examples/packet_parser/build.sh
@@ -2,10 +2,8 @@
 BPF_PROG_NAME="kern"
 USER_PROG_NAME="user"
 OUT_DIR="ebpf_output"
-LLVM_DIS=llvm-dis-9
 LLC_OPTIONS="-march=bpf -filetype=obj"
-LLC=llc-9
-OUT_BC=$OUT_DIR"/"$BPF_PROG_NAME".bc"
+LLC=llc
 OUT_IR_TEMP=$OUT_DIR"/"$BPF_PROG_NAME"_temp.ll"
 OUT_IR=$OUT_DIR"/"$BPF_PROG_NAME".ll"
 OUT_ELF=$OUT_DIR"/"$BPF_PROG_NAME".o"
@@ -13,13 +11,12 @@ RM_UND=./remove_undefined_functions.sh
 
 mkdir -p $OUT_DIR
 TARGET_DIRECTORY="target/release/deps"
-TARGET=$(echo $TARGET_DIRECTORY"/kern*.bc")
+TARGET=$(echo $TARGET_DIRECTORY"/kern*.ll")
 if [ -d $TARGET_DIRECTORY ]; then
     rm -f $TARGET
 fi
-cargo rustc --lib --release -- --emit=llvm-bc
-cp $TARGET $OUT_BC
-$LLVM_DIS $OUT_BC -o $OUT_IR_TEMP
+cargo rustc --lib --release -- --emit=llvm-ir
+cp $TARGET $OUT_IR_TEMP
 $RM_UND $OUT_IR_TEMP $OUT_IR
 $LLC $OUT_IR $LLC_OPTIONS -o $OUT_ELF 
 #llvm-objcopy $OUT_ELF --remove-section=.text

--- a/examples/packet_parser/remove_undefined_functions.sh
+++ b/examples/packet_parser/remove_undefined_functions.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 INPUT_OBJ=$1
 OUTPUT_OBJ=$2
-cat $INPUT_OBJ | sed -E "s/(.*)call(.*)slice_index_len_fail(.*)/  ret i32 0/" | sed -E "s/(.*)call(.*)slice_index_order_fail(.*)/  ret i32 0/" | sed -E "s/(.*)call(.*)panic_bounds_check(.*)/  ret i32 0/" | sed -E "s/unreachable//" > $OUTPUT_OBJ
+cat $INPUT_OBJ | sed -zE "s/\n([^;\n]*)call([^\n]*)std::panic::Location([^\n]*)\n  unreachable\n/\n  ret i32 0\n/g" > $OUTPUT_OBJ

--- a/examples/packet_parser/src/user.rs
+++ b/examples/packet_parser/src/user.rs
@@ -167,7 +167,7 @@ fn run(
     Ok(())
 }
 
-fn main() {
+fn main() -> Result<(), rebpf_error::Error> {
     let matches = App::new("packet_parser")
         .version("1.0")
         .author("Lorenzo Vannucci lorenzo@vannucci.io")
@@ -192,14 +192,11 @@ fn main() {
     let interface_name = matches.value_of("i").unwrap_or(DEFAULT_DEV);
     let unload_program = matches.is_present("U");
     let bpf_program_path = Path::new(DEFAULT_FILENAME);
-    match run(
+    run(
         &bpf_program_path,
         interface_name,
         DEFAULT_PROG_SEC,
         DEFAULT_MAPNAME,
         unload_program,
-    ) {
-        Err(err) => println!("{:?}", err),
-        Ok(_) => {}
-    };
+    )
 }


### PR DESCRIPTION
I had some issues with compiling and loading examples. LLVM version required is 9, but my rustc uses 11, which might be in cause. I tried with LLVM11, but got
```
llc: error: llc: ebpf_output/kern.ll:29:6: error: Expected 'gv', 'module', or 'typeid' at the start of summary entry
^4 = blockcount: 1
```
I don't get this issue when not disassembling bitcode but asking rustc for ir directly.
`remove_undefined_functions.sh` was not removing enough function calls to run the `packet_parser` for me. Instead of listing manually functions to remove, I changed for something that replace functions that never returns, and take a panic location. Even if such symbol was actually valid, I doubt panicking works in bpf.

On a less "don't work for me" side, I changed a bit userspace loaders so they exit with non-zero code on error, and made so the prog_by_name example actually allow to choose which program get loaded without recompiling.

Changes were tested on latest stable (1.51.0), and latest fully working nightly (1.53.0 07e0e2ec2 2021-03-24), on up to date Archlinux.