### PR TITLE
add docker build environment

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,3 @@
+FROM rust:1.51.0-bullseye
+RUN apt update
+RUN apt -y install libelf-dev llvm-11

--- a/docker/build_docker.sh
+++ b/docker/build_docker.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+IMAGE=bpf-build
+TOP_DIR="$(cargo metadata --format-version=1 | grep -o 'path+file:///[^)]*' | sed -e '$!{N;s/^\(.*\).*\n\1\/.*$/\1\n\1/;D;}' | cut -c13-)"
+BUILD_DIR=${PWD#"$TOP_DIR"}
+CARGO_CACHE="/tmp/bpf-cargo-"$(whoami)
+mkdir $CARGO_CACHE 2>/dev/null
+docker run --rm --user=$(id -u) -w /project/$BUILD_DIR \
+		--volume="$TOP_DIR":/project --volume="$CARGO_CACHE":/usr/local/cargo/registry \
+		$IMAGE /bin/sh ./build.sh

--- a/examples/basic01_xdp_pass/build.sh
+++ b/examples/basic01_xdp_pass/build.sh
@@ -1,9 +1,9 @@
-#!/bin/bash
+#!/bin/sh
 BPF_PROG_NAME="kern"
 USER_PROG_NAME="user"
 OUT_DIR="ebpf_output"
 LLC_OPTIONS="-march=bpf -filetype=obj"
-LLC=llc
+LLC=$(which llc-11 2>/dev/null || which llc)
 OUT_IR_TEMP=$OUT_DIR"/"$BPF_PROG_NAME"_temp.ll"
 OUT_IR=$OUT_DIR"/"$BPF_PROG_NAME".ll"
 OUT_ELF=$OUT_DIR"/"$BPF_PROG_NAME".o"

--- a/examples/basic01_xdp_pass/build_docker.sh
+++ b/examples/basic01_xdp_pass/build_docker.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec ../../docker/build_docker.sh

--- a/examples/basic02_prog_by_name/build.sh
+++ b/examples/basic02_prog_by_name/build.sh
@@ -1,9 +1,9 @@
-#!/bin/bash
+#!/bin/sh
 BPF_PROG_NAME="kern"
 USER_PROG_NAME="user"
 OUT_DIR="ebpf_output"
 LLC_OPTIONS="-march=bpf -filetype=obj"
-LLC=llc
+LLC=$(which llc-11 2>/dev/null || which llc)
 OUT_IR_TEMP=$OUT_DIR"/"$BPF_PROG_NAME"_temp.ll"
 OUT_IR=$OUT_DIR"/"$BPF_PROG_NAME".ll"
 OUT_ELF=$OUT_DIR"/"$BPF_PROG_NAME".o"

--- a/examples/basic02_prog_by_name/build_docker.sh
+++ b/examples/basic02_prog_by_name/build_docker.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec ../../docker/build_docker.sh

--- a/examples/empty_project/build.sh
+++ b/examples/empty_project/build.sh
@@ -1,9 +1,9 @@
-#!/bin/bash
+#!/bin/sh
 BPF_PROG_NAME="kern"
 USER_PROG_NAME="user"
 OUT_DIR="ebpf_output"
 LLC_OPTIONS="-march=bpf -filetype=obj"
-LLC=llc
+LLC=$(which llc-11 2>/dev/null || which llc)
 OUT_IR_TEMP=$OUT_DIR"/"$BPF_PROG_NAME"_temp.ll"
 OUT_IR=$OUT_DIR"/"$BPF_PROG_NAME".ll"
 OUT_ELF=$OUT_DIR"/"$BPF_PROG_NAME".o"

--- a/examples/empty_project/build_docker.sh
+++ b/examples/empty_project/build_docker.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+IMAGE=bpf-build
+TOP_DIR="$(cargo metadata --format-version=1 | grep -o 'path+file:///[^)]*' | sed -e '$!{N;s/^\(.*\).*\n\1\/.*$/\1\n\1/;D;}' | cut -c13-)"
+BUILD_DIR=${PWD#"$TOP_DIR"}
+CARGO_CACHE="/tmp/bpf-cargo-"$(whoami)
+mkdir $CARGO_CACHE 2>/dev/null
+docker run --rm --user=$(id -u) -w /project/$BUILD_DIR \
+		--volume="$TOP_DIR":/project --volume="$CARGO_CACHE":/usr/local/cargo/registry \
+		$IMAGE /bin/sh ./build.sh

--- a/examples/packet_parser/build.sh
+++ b/examples/packet_parser/build.sh
@@ -1,9 +1,9 @@
-#!/bin/bash
+#!/bin/sh
 BPF_PROG_NAME="kern"
 USER_PROG_NAME="user"
 OUT_DIR="ebpf_output"
 LLC_OPTIONS="-march=bpf -filetype=obj"
-LLC=llc
+LLC=$(which llc-11 2>/dev/null || which llc)
 OUT_IR_TEMP=$OUT_DIR"/"$BPF_PROG_NAME"_temp.ll"
 OUT_IR=$OUT_DIR"/"$BPF_PROG_NAME".ll"
 OUT_ELF=$OUT_DIR"/"$BPF_PROG_NAME".o"

--- a/examples/packet_parser/build_docker.sh
+++ b/examples/packet_parser/build_docker.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec ../../docker/build_docker.sh


### PR DESCRIPTION
I made a small script to build bpf inside Docker. It won't work as is because the image was not uploaded to docker hub.
You have to run `docker build . -t bpf-build` in docker/ before running any of the build_dockers.sh script.
Before this get merged, an image like that should be uploaded, and the scripts updated to match.
Side-note, I think empty_project should be it's own repository instead of an example, so one can do <code><a href="https://github.com/cargo-generate/cargo-generate">cargo generate</a> --git &lt;repository_url&gt;</code> to create a new, empty, project.

